### PR TITLE
add high resolution minimap

### DIFF
--- a/app/logic/honeybee/honeybee_beekeeper_map.R
+++ b/app/logic/honeybee/honeybee_beekeeper_map.R
@@ -1,7 +1,7 @@
 box::use(
   terra[rast, spatSample, deepcopy, set.values, cells],
   leaflet[leaflet, addTiles, addRasterImage, addRasterLegend, addLayersControl, layersControlOptions, addScaleBar, addAwesomeMarkers, makeAwesomeIcon, setView],
-  leaflet.extras[addDrawToolbar, drawMarkerOptions],
+  leaflet.extras[removeDrawToolbar, addDrawToolbar, drawMarkerOptions],
 )
 
 #' @export
@@ -38,10 +38,23 @@ honeybee_leaflet_map <- function(map_raster,
       lng = 11.8787,
       lat = 51.3919,
       zoom = 5
-    )
+    ) |>
+    addRasterImage(
+        bee_map,
+        opacity = 0.9,
+        project = FALSE,
+        group = "Beehave layers"
+      ) |>
+      addRasterLegend(
+        bee_map,
+        opacity = 0.9,
+        position = "bottomright",
+        group = "Beehavelayers",
+        className = "info legend Beehavelayers"
+      )
 
   if (main_map_features) {
-      leaflet_map <- leaflet_map |>
+    leaflet_map <- leaflet_map |>
       addRasterImage(
         scaled_map,
         opacity = 0.5,
@@ -54,19 +67,6 @@ honeybee_leaflet_map <- function(map_raster,
         position = "bottomright",
         group = "Alllayers",
         className = "info legend Alllayers"
-      ) |>
-      addRasterImage(
-        bee_map,
-        opacity = 0.9,
-        project = FALSE,
-        group = "Beehave layers"
-      ) |>
-      addRasterLegend(
-        bee_map,
-        opacity = 0.9,
-        position = "bottomright",
-        group = "Beehavelayers",
-        className = "info legend Beehavelayers"
       ) |>
       addLayersControl(
         c("Beehave layers", "All layers"),
@@ -88,6 +88,7 @@ honeybee_leaflet_map <- function(map_raster,
       ) |>
       addScaleBar()
   }
+
 
   # LATER - viz issue #29
   # addAwesomeMarkers(11.8787,

--- a/app/logic/honeybee/honeybee_beekeeper_map.R
+++ b/app/logic/honeybee/honeybee_beekeeper_map.R
@@ -40,18 +40,18 @@ honeybee_leaflet_map <- function(map_raster,
       zoom = 5
     ) |>
     addRasterImage(
-        bee_map,
-        opacity = 0.9,
-        project = FALSE,
-        group = "Beehave layers"
-      ) |>
-      addRasterLegend(
-        bee_map,
-        opacity = 0.9,
-        position = "bottomright",
-        group = "Beehavelayers",
-        className = "info legend Beehavelayers"
-      )
+      bee_map,
+      opacity = 0.9,
+      project = FALSE,
+      group = "Beehave layers"
+    ) |>
+    addRasterLegend(
+      bee_map,
+      opacity = 0.9,
+      position = "bottomright",
+      group = "Beehavelayers",
+      className = "info legend Beehavelayers"
+    )
 
   if (main_map_features) {
     leaflet_map <- leaflet_map |>
@@ -88,7 +88,6 @@ honeybee_leaflet_map <- function(map_raster,
       ) |>
       addScaleBar()
   }
-
 
   # LATER - viz issue #29
   # addAwesomeMarkers(11.8787,

--- a/app/logic/honeybee/honeybee_beekeeper_map.R
+++ b/app/logic/honeybee/honeybee_beekeeper_map.R
@@ -38,7 +38,7 @@ honeybee_leaflet_map <- function(map_raster,
       scaled_map,
       opacity = 0.5,
       project = FALSE,
-      group = "All layers"
+      group = "Alllayers"
     ) |>
     addRasterLegend(
       scaled_map,

--- a/app/logic/honeybee/honeybee_beekeeper_map.R
+++ b/app/logic/honeybee/honeybee_beekeeper_map.R
@@ -13,6 +13,7 @@ read_honeybee_tif <- function(map_path) {
 honeybee_leaflet_map <- function(map_raster,
                                  lookup_table = NULL,
                                  add_control = TRUE,
+                                 main_map_features = TRUE,
                                  scale = TRUE) {
   icon.fa <- makeAwesomeIcon(icon = "check", markerColor = "cadetblue", library = "fa", iconColor = "#fff")
 
@@ -31,49 +32,48 @@ honeybee_leaflet_map <- function(map_raster,
   set.values(scaled_map, cells(scaled_map, c(0, 24)) |> unlist(), NA)
   set.values(bee_map, cells(bee_map, setdiff(0:24, c(8, 9, 10, 14, 15, 16, 18, 19))) |> unlist(), NA)
 
-  leaflet_map <-
-    leaflet() |>
+  leaflet_map <- leaflet() |>
     addTiles() |>
-    addRasterImage(
-      scaled_map,
-      opacity = 0.5,
-      project = FALSE,
-      group = "Alllayers"
-    ) |>
-    addRasterLegend(
-      scaled_map,
-      opacity = 0.5,
-      position = "bottomright",
-      group = "Alllayers",
-      className = "info legend Alllayers"
-    ) |>
-    addRasterImage(
-      bee_map,
-      opacity = 0.9,
-      project = FALSE,
-      group = "Beehave layers"
-    ) |>
-    addRasterLegend(
-      bee_map,
-      opacity = 0.9,
-      position = "bottomright",
-      group = "Beehavelayers",
-      className = "info legend Beehavelayers"
-    ) |>
-    addLayersControl(
-      c("Beehave layers", "All layers"),
-      position = "topright",
-      options = layersControlOptions(collapsed = FALSE)
-    ) |>
-    # addAwesomeMarkers(11.8787,
-    #                   51.3919,
-    #                   label = htmltools::HTML("<strong>Example</strong>"),
-    #                   icon = icon.fa) |>
-    setView(11.8787,
-      51.3919,
+    setView(
+      lng = 11.8787,
+      lat = 51.3919,
       zoom = 5
     )
 
+  if (main_map_features) {
+      leaflet_map <- leaflet_map |>
+      addRasterImage(
+        scaled_map,
+        opacity = 0.5,
+        project = FALSE,
+        group = "Alllayers"
+      ) |>
+      addRasterLegend(
+        scaled_map,
+        opacity = 0.5,
+        position = "bottomright",
+        group = "Alllayers",
+        className = "info legend Alllayers"
+      ) |>
+      addRasterImage(
+        bee_map,
+        opacity = 0.9,
+        project = FALSE,
+        group = "Beehave layers"
+      ) |>
+      addRasterLegend(
+        bee_map,
+        opacity = 0.9,
+        position = "bottomright",
+        group = "Beehavelayers",
+        className = "info legend Beehavelayers"
+      ) |>
+      addLayersControl(
+        c("Beehave layers", "All layers"),
+        position = "topright",
+        options = layersControlOptions(collapsed = FALSE)
+      )
+  }
 
   if (add_control) {
     leaflet_map <- leaflet_map |>
@@ -88,6 +88,12 @@ honeybee_leaflet_map <- function(map_raster,
       ) |>
       addScaleBar()
   }
+
+  # LATER - viz issue #29
+  # addAwesomeMarkers(11.8787,
+  #                   51.3919,
+  #                   label = htmltools::HTML("<strong>Example</strong>"),
+  #                   icon = icon.fa) |>
 
   return(leaflet_map)
 }

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -158,7 +158,7 @@ honeybee_map_server <- function(id,
               setView(
                 long,
                 lat,
-                zoom = 12
+                zoom = 10
               )
 
             observeEvent(input$map_mini_bounds, {

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -1,6 +1,6 @@
 box::use(shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
          bslib[card, card_header, card_body],
-         leaflet[removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
+         leaflet[flyTo, fitBounds, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
          htmlwidgets[onRender],
          terra[vect, extract, project, buffer, crop],
          )
@@ -41,7 +41,7 @@ honeybee_map_ui <- function(id, i18n) {
           ),
           tags$div(
             class = "col-lg-6 col-sm-12",
-            leafletOutput(ns("map_mini"), height = "200px"),
+            leafletOutput(ns("map_mini"), height = "256px"),
           )
         ),
         leafletOutput(ns("map_plot"),
@@ -149,7 +149,7 @@ honeybee_map_server <- function(id,
                        clip_buffer <- buffer(pts, 3000)
                        # Crop area from the map and create unscaled map for minimap
                        crop(map(), clip_buffer) |>
-                         honeybee_leaflet_map(main_map_features = FALSE, scale = FALSE) |>
+                         honeybee_leaflet_map(add_control = FALSE, main_map_features = FALSE, scale = FALSE) |>
                          zoomed_map()
 
                        observeEvent(zoomed_map(), {
@@ -157,18 +157,14 @@ honeybee_map_server <- function(id,
                            setView(
                              long,
                              lat,
-                             zoom = 13
+                             zoom = 12
                            )
 
-
-                         leafletProxy("map_mini", session) |>
-                           removeShape(layerId = "circle") |>
-                           addCircles(
-                             lng = long,
-                             lat = lat,
-                             radius = 3000,
-                             layerId = "circle"
-                           )
+                          observeEvent(input$map_mini_bounds,
+                          {
+                            leafletProxy("map_mini", session) |>
+                              flyTo(long, lat, zoom = 13)
+                          })
 
                          output$map_mini <- renderLeaflet(output_zoomed)
                        })

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -159,13 +159,8 @@ honeybee_map_server <- function(id,
               setView(
                 long,
                 lat,
-                zoom = 10
+                zoom = 13
               )
-
-            observeEvent(input$map_mini_bounds, {
-              leafletProxy("map_mini", session) |>
-                setView(long, lat, zoom = 13)
-            })
 
             output$map_mini <- renderLeaflet(output_zoomed)
           })

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -103,9 +103,9 @@ honeybee_map_server <- function(id,
         removeShape(layerId = "rect") |>
         addRectangles(
           lng1 = long - 0.027131078,
-          lat1 = lat - 0.027131078,
+          lat1 = lat - 0.016125,
           lng2 = long + 0.027131078,
-          lat2 = lat + 0.027131078,
+          lat2 = lat + 0.016125,
           layerId = "rect"
         )
 
@@ -141,8 +141,7 @@ honeybee_map_server <- function(id,
               lat,
               "<br>",
               "Longitude: ",
-              long,
-              "<br>"
+              long
             )
           ) |>
             coordinates_text()
@@ -160,6 +159,14 @@ honeybee_map_server <- function(id,
                 long,
                 lat,
                 zoom = 13
+              ) |>
+              removeShape(layerId = "rect2") |>
+              addRectangles(
+                lng1 = long - 0.027131078,
+                lat1 = lat - 0.016125,
+                lng2 = long + 0.027131078,
+                lat2 = lat + 0.016125,
+                layerId = "rect2"
               )
 
             output$map_mini <- renderLeaflet(output_zoomed)

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -4,6 +4,7 @@ box::use(
   leaflet[addRectangles, flyTo, fitBounds, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
   htmlwidgets[onRender],
   terra[vect, extract, project, buffer, crop],
+  shinyjs[hide, show, useShinyjs]
 )
 
 box::use(
@@ -14,6 +15,7 @@ box::use(
 honeybee_map_ui <- function(id, i18n) {
   ns <- NS(id)
   tagList(
+    useShinyjs(),
     card(
       class = "ms-md-3 card-shadow",
       title = "input_map",
@@ -69,6 +71,9 @@ honeybee_map_server <- function(id,
 
     output$acknowledgment <- renderText(map_acknowledgment())
 
+    # do not show minimap by default
+    hide("map_mini")
+
     observeEvent(leaflet_map(), {
       output_map <- leaflet_map() |>
         onRender(
@@ -106,7 +111,8 @@ honeybee_map_server <- function(id,
           lat1 = lat - 0.016125,
           lng2 = long + 0.027131078,
           lat2 = lat + 0.016125,
-          layerId = "rect"
+          layerId = "rect",
+          fillColor = "transparent"
         )
 
       if (length(input$map_plot_draw_new_feature) > 0) {
@@ -134,6 +140,7 @@ honeybee_map_server <- function(id,
           out(NULL)
           zoomed_map(NULL)
         } else {
+          show("map_mini")
           HTML(
             paste(
               "Selected coordinates are: <br>",
@@ -166,7 +173,8 @@ honeybee_map_server <- function(id,
                 lat1 = lat - 0.016125,
                 lng2 = long + 0.027131078,
                 lat2 = lat + 0.016125,
-                layerId = "rect2"
+                layerId = "rect2",
+                fillColor = "transparent"
               )
 
             output$map_mini <- renderLeaflet(output_zoomed)

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -1,8 +1,9 @@
 box::use(shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
          bslib[card, card_header, card_body],
-         leaflet[leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape],
+         leaflet[setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
          htmlwidgets[onRender],
          terra[vect, extract, project, buffer, crop],
+         leaflet.extras[removeDrawToolbar],
          )
 
 box::use(
@@ -115,9 +116,7 @@ honeybee_map_server <- function(id,
                      pts <- vect(pts_longlat, crs = "epsg:4326") |>
                        project("epsg:3857")
                      
-                     print(pts)
                      extracted <- extract(map(), pts)
-                     print(extracted)
                      
                      if (is.na(extracted$category) ||
                          extracted$category == "Unclassified") {
@@ -155,9 +154,15 @@ honeybee_map_server <- function(id,
                          zoomed_map()
 
                        observeEvent(zoomed_map(), {
-                         output_map <- zoomed_map()
+                         output_zoomed <- zoomed_map() |>
+                           setView(
+                             long,
+                             lat,
+                             zoom = 18
+                           ) |>
+                           removeDrawToolbar(clearFeatures = FALSE)
 
-                         output$map_mini <- renderLeaflet(output_map)
+                         output$map_mini <- renderLeaflet(output_zoomed)
                        })
 
                        # Sent coordinates to out reactive value to use it outside module

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -1,6 +1,6 @@
 box::use(shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
          bslib[card, card_header, card_body],
-         leaflet[setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
+         leaflet[clearGroup, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
          htmlwidgets[onRender],
          terra[vect, extract, project, buffer, crop],
          )
@@ -166,7 +166,9 @@ honeybee_map_server <- function(id,
                              lat = lat,
                              radius = 3000,
                              layerId = "circle"
-                           )
+                           ) |>
+                           removeLayersControl() |>
+                           clearGroup("Alllayers")
 
                          output$map_mini <- renderLeaflet(output_zoomed)
                        })

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -1,6 +1,6 @@
 box::use(shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
          bslib[card, card_header, card_body],
-         leaflet[clearGroup, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
+         leaflet[setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
          htmlwidgets[onRender],
          terra[vect, extract, project, buffer, crop],
          )
@@ -18,9 +18,11 @@ honeybee_map_ui <- function(id, i18n) {
       title = "input_map",
       id = ns("input_map"),
       full_screen = TRUE,
-      card_header(tags$h2(
-                    class = "card_title",
-                    "Input Map"), ),
+      card_header(
+        tags$h2(
+          class = "card_title",
+          "Input Map"
+      )),
       card_body(
         id = ns("map_input_card"),
         tags$div(
@@ -117,8 +119,7 @@ honeybee_map_server <- function(id,
                      
                      extracted <- extract(map(), pts)
                      
-                     if (is.na(extracted$category) ||
-                         extracted$category == "Unclassified") {
+                     if (is.na(extracted$category) || extracted$category == "Unclassified") {
                        HTML(
                          paste(
                            "<span class='text-danger'>",
@@ -148,7 +149,7 @@ honeybee_map_server <- function(id,
                        clip_buffer <- buffer(pts, 3000)
                        # Crop area from the map and create unscaled map for minimap
                        crop(map(), clip_buffer) |>
-                         honeybee_leaflet_map(add_control = FALSE, scale = FALSE) |>
+                         honeybee_leaflet_map(main_map_features = FALSE, scale = FALSE) |>
                          zoomed_map()
 
                        observeEvent(zoomed_map(), {
@@ -166,9 +167,7 @@ honeybee_map_server <- function(id,
                              lat = lat,
                              radius = 3000,
                              layerId = "circle"
-                           ) |>
-                           removeLayersControl() |>
-                           clearGroup("Alllayers")
+                           )
 
                          output$map_mini <- renderLeaflet(output_zoomed)
                        })

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -1,6 +1,6 @@
 box::use(shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
          bslib[card, card_header, card_body],
-         leaflet[setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
+         leaflet[removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
          htmlwidgets[onRender],
          terra[vect, extract, project, buffer, crop],
          )
@@ -159,6 +159,7 @@ honeybee_map_server <- function(id,
                              lat,
                              zoom = 13
                            )
+
 
                          leafletProxy("map_mini", session) |>
                            removeShape(layerId = "circle") |>

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -36,6 +36,10 @@ honeybee_map_ui <- function(id, i18n) {
               "desired placement on the map."
             ),
             uiOutput(ns("map_coordinates"),),
+          ),
+          tags$div(
+            class = "col-lg-6 col-sm-12",
+            leafletOutput(ns("map_mini"), height = "200px"),
           )
         ),
         leafletOutput(ns("map_plot"),
@@ -146,10 +150,16 @@ honeybee_map_server <- function(id,
                        clip_buffer <- buffer(pts, 
                                              3000)
                        # Crop area from the map and create unscaled map for minimap
-                       crop(map(),
-                            clip_buffer) |>
+                       crop(map(), clip_buffer) |>
                          honeybee_leaflet_map(scale = FALSE) |>
                          zoomed_map()
+
+                       observeEvent(zoomed_map(), {
+                         output_map <- zoomed_map()
+
+                         output$map_mini <- renderLeaflet(output_map)
+                       })
+
                        # Sent coordinates to out reactive value to use it outside module
                        data.frame(lat = lat,
                                   lon = long) |>

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -3,7 +3,6 @@ box::use(shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observ
          leaflet[setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
          htmlwidgets[onRender],
          terra[vect, extract, project, buffer, crop],
-         leaflet.extras[removeDrawToolbar],
          )
 
 box::use(
@@ -146,11 +145,10 @@ honeybee_map_server <- function(id,
                          coordinates_text()
                        
                        # Choose area around the selected point
-                       clip_buffer <- buffer(pts, 
-                                             3000)
+                       clip_buffer <- buffer(pts, 3000)
                        # Crop area from the map and create unscaled map for minimap
                        crop(map(), clip_buffer) |>
-                         honeybee_leaflet_map(scale = FALSE) |>
+                         honeybee_leaflet_map(add_control = FALSE, scale = FALSE) |>
                          zoomed_map()
 
                        observeEvent(zoomed_map(), {
@@ -158,9 +156,17 @@ honeybee_map_server <- function(id,
                            setView(
                              long,
                              lat,
-                             zoom = 18
-                           ) |>
-                           removeDrawToolbar(clearFeatures = FALSE)
+                             zoom = 13
+                           )
+
+                         leafletProxy("map_mini", session) |>
+                           removeShape(layerId = "circle") |>
+                           addCircles(
+                             lng = long,
+                             lat = lat,
+                             radius = 3000,
+                             layerId = "circle"
+                           )
 
                          output$map_mini <- renderLeaflet(output_zoomed)
                        })

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -1,7 +1,7 @@
 box::use(
   shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
   bslib[card, card_header, card_body],
-  leaflet[flyTo, fitBounds, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
+  leaflet[addRectangles, flyTo, fitBounds, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
   htmlwidgets[onRender],
   terra[vect, extract, project, buffer, crop],
 )
@@ -100,12 +100,13 @@ honeybee_map_server <- function(id,
         input$map_plot_draw_new_feature$geometry$coordinates[[1]]
 
       leafletProxy("map_plot", session) |>
-        removeShape(layerId = "circle") |>
-        addCircles(
-          lng = long,
-          lat = lat,
-          radius = 3000,
-          layerId = "circle"
+        removeShape(layerId = "rect") |>
+        addRectangles(
+          lng1 = long - 0.027131078,
+          lat1 = lat - 0.027131078,
+          lng2 = long + 0.027131078,
+          lat2 = lat + 0.027131078,
+          layerId = "rect"
         )
 
       if (length(input$map_plot_draw_new_feature) > 0) {
@@ -163,7 +164,7 @@ honeybee_map_server <- function(id,
 
             observeEvent(input$map_mini_bounds, {
               leafletProxy("map_mini", session) |>
-                flyTo(long, lat, zoom = 13)
+                setView(long, lat, zoom = 13)
             })
 
             output$map_mini <- renderLeaflet(output_zoomed)

--- a/app/view/honeybee/beekeeper_map.R
+++ b/app/view/honeybee/beekeeper_map.R
@@ -1,12 +1,13 @@
-box::use(shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
-         bslib[card, card_header, card_body],
-         leaflet[flyTo, fitBounds, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
-         htmlwidgets[onRender],
-         terra[vect, extract, project, buffer, crop],
-         )
+box::use(
+  shiny[moduleServer, NS, tagList, tags, uiOutput, renderUI, HTML, observeEvent, reactiveVal, reactive, textOutput, renderText],
+  bslib[card, card_header, card_body],
+  leaflet[flyTo, fitBounds, removeLayersControl, setView, leafletOutput, renderLeaflet, leafletProxy, addCircles, removeShape, clearControls],
+  htmlwidgets[onRender],
+  terra[vect, extract, project, buffer, crop],
+)
 
 box::use(
-  app/logic/honeybee/honeybee_beekeeper_map[honeybee_leaflet_map],
+  app / logic / honeybee / honeybee_beekeeper_map[honeybee_leaflet_map],
 )
 
 #' @export
@@ -22,7 +23,8 @@ honeybee_map_ui <- function(id, i18n) {
         tags$h2(
           class = "card_title",
           "Input Map"
-      )),
+        )
+      ),
       card_body(
         id = ns("map_input_card"),
         tags$div(
@@ -37,7 +39,7 @@ honeybee_map_ui <- function(id, i18n) {
               tags$b("select"),
               "desired placement on the map."
             ),
-            uiOutput(ns("map_coordinates"),),
+            uiOutput(ns("map_coordinates"), ),
           ),
           tags$div(
             class = "col-lg-6 col-sm-12",
@@ -45,7 +47,8 @@ honeybee_map_ui <- function(id, i18n) {
           )
         ),
         leafletOutput(ns("map_plot"),
-                      height = "500px"),
+          height = "500px"
+        ),
         textOutput(ns("acknowledgment"))
       )
     ),
@@ -63,9 +66,9 @@ honeybee_map_server <- function(id,
     coordinates_text <- reactiveVal()
     out <- reactiveVal(NULL)
     zoomed_map <- reactiveVal(NULL)
-    
+
     output$acknowledgment <- renderText(map_acknowledgment())
-    
+
     observeEvent(leaflet_map(), {
       output_map <- leaflet_map() |>
         onRender(
@@ -74,8 +77,8 @@ honeybee_map_server <- function(id,
       function(el, x) {
          var updateLegend = function () {
             var selectedGroup = document.querySelectorAll('#",
-      ns("map_plot"),
-      " input:checked')[0].nextSibling.innerText.substr(1);
+            ns("map_plot"),
+            " input:checked')[0].nextSibling.innerText.substr(1);
             var selectedClass = selectedGroup.replace(' ', '');
             document.querySelectorAll('.legend').forEach(a => a.hidden=true);
             document.querySelectorAll('.legend').forEach(l => {
@@ -87,109 +90,107 @@ honeybee_map_server <- function(id,
       }"
           )
         )
-      
+
       output$map_plot <- renderLeaflet(output_map)
     })
-    
-    observeEvent(input$map_plot_draw_new_feature,
-                 {
-                   lat <- input$map_plot_draw_new_feature$geometry$coordinates[[2]]
-                   long <-
-                     input$map_plot_draw_new_feature$geometry$coordinates[[1]]
-                   
-                   leafletProxy("map_plot", session) |>
-                     removeShape(layerId = "circle") |>
-                     addCircles(
-                       lng = long,
-                       lat = lat,
-                       radius = 3000,
-                       layerId = "circle"
-                     )
-                   
-                   
-                   if (length(input$map_plot_draw_new_feature) > 0) {
-                     # https://www.paulamoraga.com/book-spatial/the-terra-package-for-raster-and-vector-data.html#vector-data-1
-                     pts_long <- c(long)
-                     pts_lat <- c(lat)
-                     
-                     pts_longlat <- cbind(pts_long, pts_lat)
-                     
-                     pts <- vect(pts_longlat, crs = "epsg:4326") |>
-                       project("epsg:3857")
-                     
-                     extracted <- extract(map(), pts)
-                     
-                     if (is.na(extracted$category) || extracted$category == "Unclassified") {
-                       HTML(
-                         paste(
-                           "<span class='text-danger'>",
-                           "WARNING! Selected location is outside boundaries.",
-                           "</span>"
-                         )
-                       ) |>
-                         coordinates_text()
-                       
-                       out(NULL)
-                       zoomed_map(NULL)
-                     } else {
-                       HTML(
-                         paste(
-                           "Selected coordinates are: <br>",
-                           "Latitude: ",
-                           lat,
-                           "<br>",
-                           "Longitude: ",
-                           long,
-                           "<br>"
-                         )
-                       ) |>
-                         coordinates_text()
-                       
-                       # Choose area around the selected point
-                       clip_buffer <- buffer(pts, 3000)
-                       # Crop area from the map and create unscaled map for minimap
-                       crop(map(), clip_buffer) |>
-                         honeybee_leaflet_map(add_control = FALSE, main_map_features = FALSE, scale = FALSE) |>
-                         zoomed_map()
 
-                       observeEvent(zoomed_map(), {
-                         output_zoomed <- zoomed_map() |>
-                           setView(
-                             long,
-                             lat,
-                             zoom = 12
-                           )
+    observeEvent(input$map_plot_draw_new_feature, {
+      lat <- input$map_plot_draw_new_feature$geometry$coordinates[[2]]
+      long <-
+        input$map_plot_draw_new_feature$geometry$coordinates[[1]]
 
-                          observeEvent(input$map_mini_bounds,
-                          {
-                            leafletProxy("map_mini", session) |>
-                              flyTo(long, lat, zoom = 13)
-                          })
+      leafletProxy("map_plot", session) |>
+        removeShape(layerId = "circle") |>
+        addCircles(
+          lng = long,
+          lat = lat,
+          radius = 3000,
+          layerId = "circle"
+        )
 
-                         output$map_mini <- renderLeaflet(output_zoomed)
-                       })
+      if (length(input$map_plot_draw_new_feature) > 0) {
+        # https://www.paulamoraga.com/book-spatial/the-terra-package-for-raster-and-vector-data.html#vector-data-1
+        pts_long <- c(long)
+        pts_lat <- c(lat)
 
-                       # Sent coordinates to out reactive value to use it outside module
-                       data.frame(lat = lat,
-                                  lon = long) |>
-                         out()
-                     }
-                   } else {
-                     coordinates_text("No location selected.")
-                     out(NULL)
-                     zoomed_map(NULL)
-                   }
-                 })
-    
+        pts_longlat <- cbind(pts_long, pts_lat)
+
+        pts <- vect(pts_longlat, crs = "epsg:4326") |>
+          project("epsg:3857")
+
+        extracted <- extract(map(), pts)
+
+        if (is.na(extracted$category) || extracted$category == "Unclassified") {
+          HTML(
+            paste(
+              "<span class='text-danger'>",
+              "WARNING! Selected location is outside boundaries.",
+              "</span>"
+            )
+          ) |>
+            coordinates_text()
+
+          out(NULL)
+          zoomed_map(NULL)
+        } else {
+          HTML(
+            paste(
+              "Selected coordinates are: <br>",
+              "Latitude: ",
+              lat,
+              "<br>",
+              "Longitude: ",
+              long,
+              "<br>"
+            )
+          ) |>
+            coordinates_text()
+
+          # Choose area around the selected point
+          clip_buffer <- buffer(pts, 3000)
+          # Crop area from the map and create unscaled map for minimap
+          crop(map(), clip_buffer) |>
+            honeybee_leaflet_map(add_control = FALSE, main_map_features = FALSE, scale = FALSE) |>
+            zoomed_map()
+
+          observeEvent(zoomed_map(), {
+            output_zoomed <- zoomed_map() |>
+              setView(
+                long,
+                lat,
+                zoom = 12
+              )
+
+            observeEvent(input$map_mini_bounds, {
+              leafletProxy("map_mini", session) |>
+                flyTo(long, lat, zoom = 13)
+            })
+
+            output$map_mini <- renderLeaflet(output_zoomed)
+          })
+
+          # Sent coordinates to out reactive value to use it outside module
+          data.frame(
+            lat = lat,
+            lon = long
+          ) |>
+            out()
+        }
+      } else {
+        coordinates_text("No location selected.")
+        out(NULL)
+        zoomed_map(NULL)
+      }
+    })
+
     output$map_coordinates <- renderUI(coordinates_text())
-    
-    observeEvent(experiment_list(),
-                 {
-                   # Add code to add awesomemarker to the map with the name of the list values in the label.
-                   new_name <- names(experiment_list)[length(experiment_list)]
-                 })
-    
-    
+
+    observeEvent(experiment_list(), {
+      # Add code to add awesomemarker to the map with the name of the list values in the label.
+      new_name <- names(experiment_list)[length(experiment_list)]
+    })
+
+
     reactive(out())
   })
 }

--- a/app/view/honeybee/honeybee_beekeeper.R
+++ b/app/view/honeybee/honeybee_beekeeper.R
@@ -97,7 +97,10 @@ honeybee_beekeeper_server <- function(id,
           map()
 
         map() |>
-          honeybee_leaflet_map() |>
+          honeybee_leaflet_map(
+            add_control = TRUE,
+            main_map_features = TRUE,
+          ) |>
           leaflet_map()
 
         # Lookup table


### PR DESCRIPTION
I'm opening PR... still supposing that there will be additional edits to the branch.

- In comparison to the assigned task #76 the "minimap" is shown based on a click(s) in the main map, **not onHover**. I would propose that it's going to be like that, "onHover" seems to me as a really unnecessary overhead, too much interactivity.
- The "minimap" is rendered **without draw control (toolbar)**. It would be perplexing for a user to choose the location in two different places, in two different maps.
- I kept there raster info legends ("land use types") but due to a smaller size of the minimap the legend is very often not shown entirely. What to do? Add CSS class to legend with smaller font e.g. `font-size: 10px` (replacing default `font: 14px/16px Arial, Helvetica, sans-serif;`)...? Something else?