### PR TITLE
Add custom container for CI

### DIFF
--- a/.github/workflows/rhino-test.yml
+++ b/.github/workflows/rhino-test.yml
@@ -6,29 +6,11 @@ jobs:
   main:
     name: Run linters and tests
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/biodt/shiny-ci:0.1.0
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Setup system dependencies
-        run: |
-          packages=(
-            libgdal-dev
-            libcurl4-openssl-dev
-            libproj-dev
-            libudunits2-dev
-            # List each package on a separate line.
-          )
-          sudo apt-get update
-          sudo apt-get install --yes "${packages[@]}"
-
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: renv
-
-      - name: Setup R dependencies
-        uses: r-lib/actions/setup-renv@v2
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,53 @@
+# Container images
+
+General workflow for container images is:
+1. Image is built on a local computer using Podman/Docker
+2. Image is pushed to GitHub container registry (ghcr.io)
+
+For each directory, there are two files:
+- `Dockerfile`: This is the recipe for building a container image
+- `Makefile`: This is a helper file for simplifying building the image (so that one can say `make build` instead of `docker buildx build --platform ... --build-arg ...`)
+
+
+## First-time setup on Ubuntu
+
+Install docker or podman:
+
+    sudo apt install podman-docker
+
+Add the following environment variable to `~/.bashrc` or redefine it always before running build commands:
+
+    export BUILDAH_FORMAT=docker
+
+
+## Updating and building a new image
+
+Typical workflow is:
+
+1. **Important:** Update `IMAGE_VERSION` variable in `Makefile`. If this is not done, an existing image with the same version gets overwritten, which is problematic for reproducibility.
+
+2. Update `Dockerfile` and/or `Makefile` as needed.
+
+3. Build a new image:
+
+       make build
+
+3. Login to GitHub container registry.
+   Use GitHub username and Personal Access Token with scope 'write:packages' as username and password, respectively.
+   See [these instructions for creating a token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic).
+
+       docker login ghcr.io
+
+4. Push the image to ghcr.io:
+
+       make push
+
+
+## Using the built image via docker/podman
+
+You can test the image locally before pushing it to ghcr.io.
+
+Example for running bash with the image:
+
+    docker run -it --rm --entrypoint bash IMAGE_NAME:IMAGE_VERSION
+

--- a/containers/ci/.gitignore
+++ b/containers/ci/.gitignore
@@ -1,0 +1,1 @@
+renv.lock

--- a/containers/ci/Dockerfile
+++ b/containers/ci/Dockerfile
@@ -1,0 +1,20 @@
+FROM docker.io/rocker/r-ver:4.4.1
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy && \
+    apt-get install -qy \
+        libgdal-dev \
+        libcurl4-openssl-dev \
+        libproj-dev \
+        libudunits2-dev \
+        && \
+    apt-get clean
+
+RUN Rscript -e 'install.packages("remotes")' && \
+    Rscript -e 'remotes::install_version("renv", version = "1.0.7")'
+
+COPY renv.lock /biodt/renv.lock
+RUN cd /biodt && \
+    Rscript -e 'renv::restore()'
+

--- a/containers/ci/Makefile
+++ b/containers/ci/Makefile
@@ -1,0 +1,16 @@
+IMAGE_ROOT?=ghcr.io/biodt
+IMAGE=shiny-ci
+IMAGE_VERSION=0.1.0
+
+build: Dockerfile renv.lock
+	docker buildx build --platform linux/amd64 \
+		--label "org.opencontainers.image.source=https://github.com/BioDT/biodt-shiny" \
+		--label "org.opencontainers.image.description=BioDT Shiny CI environment" \
+		-t ${IMAGE_ROOT}/${IMAGE}:${IMAGE_VERSION} \
+		.
+
+push:
+	docker push ${IMAGE_ROOT}/${IMAGE}:${IMAGE_VERSION}
+
+renv.lock: ../../renv.lock
+	cp -v $< $@


### PR DESCRIPTION
This PR will add a custom container for running CI. The initial image version is already pushed to [ghcr.io](https://github.com/BioDT/biodt-shiny/pkgs/container/shiny-ci) and tested with CI.

The other container variants could be pushed to ghcr.io similarly.