### PR TITLE
Small changes in beehave k8s execution

### DIFF
--- a/app/logic/honeybee/k8s.R
+++ b/app/logic/honeybee/k8s.R
@@ -11,6 +11,7 @@ box::use(
     resp_check_status,
     resp_stream_lines
   ],
+  jsonlite[fromJSON],
 )
 
 create_and_wait_k8s_job <- function(data_subpath, run_id) {
@@ -44,7 +45,7 @@ create_and_wait_k8s_job <- function(data_subpath, run_id) {
           containers = list(
             list(
               name = "beehave",
-              image = "ghcr.io/biodt/beehave:0.3.9",
+              image = "ghcr.io/biodt/beehave:0.3.11",
               command = list("/scripts/cloud/run_docker_flow.sh"),
               env = list(
                 list(name = "INPUT_DIR", value = "/data"),
@@ -64,8 +65,6 @@ create_and_wait_k8s_job <- function(data_subpath, run_id) {
                 limits = list(cpu = "1")
               ),
               volumeMounts = list(
-                list(name = "biodt-scripts-volume", mountPath = "/scripts/cloud"),
-                list(name = "biodt-pollinators-r-volume", mountPath = "/R"),
                 list(
                   name = paste0("biodt-shared-dir-volume-", shinyproxy_id),
                   mountPath = "/data",

--- a/app/view/honeybee/beekeeper_runsimulation.R
+++ b/app/view/honeybee/beekeeper_runsimulation.R
@@ -18,7 +18,6 @@ box::use(
   waiter[Waiter],
   fs[file_copy],
   utils[write.csv],
-  jsonlite[fromJSON],
   config,
 )
 
@@ -229,7 +228,7 @@ beekeeper_runsimulation_server <- function(
         } else if (config$get("executor") == "k8s") {
           data_subpath <- stringr::str_remove(
             run_dir,
-            file.path(config$get("home_path"), "shared/")
+            paste0(config$get("base_path"), "/")
           )
           create_and_wait_k8s_job(data_subpath, run_id)
         } else {

--- a/config.yml
+++ b/config.yml
@@ -16,7 +16,6 @@ prod:
 k8s:
   base_path: !expr Sys.getenv("BASE_PATH")
   data_path: !expr Sys.getenv("DATA_PATH")
-  home_path: !expr Sys.getenv("HOME_PATH")
   api_url: !expr Sys.getenv("KUBERNETES_API_URL")
   namespace: !expr Sys.getenv("KUBERNETES_NAMESPACE")
   token: !expr Sys.getenv("KUBERNETES_API_TOKEN")


### PR DESCRIPTION
This PR includes the small path and version changes required to use the new image architecture (global data mount, no scripts mount, no r mount) in the LifeWatch ERIC kubernetes infrastructure.

Before building, the shiny-base image needs to be built again (it is currently outdated).