### PR TITLE
Grassland another plot edits: labels, daylength, plot, labels

### DIFF
--- a/app/logic/grassland/grassland_multichart_bars_stack.R
+++ b/app/logic/grassland/grassland_multichart_bars_stack.R
@@ -107,7 +107,6 @@ generate_chart_bars_mean <- function(
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #D55E00\"></i>Temperature [degC]: ' + param.find(item => item.seriesName ==  'Temperature[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #E69F00\"></i>Temperature Daylight [degC]: ' + param.find(item => item.seriesName ==  'Temperature_Daylight[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #F0E442\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
-              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #009E73\"></i>Daylength [h]: ' + param.find(item => item.seriesName ==  'Daylength[h]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #56B4E9\"></i>PET [mm]: ' + param.find(item => item.seriesName ==  'PET[mm]').value
           }
         "
@@ -149,12 +148,12 @@ generate_chart_bars_mean <- function(
         )
       ),
       grid = list(
-        list(left = "10%", right = "8%", top = "4%", height = "13%"),
-        list(left = "10%", right = "8%", top = "22%", height = "13%"),
-        list(left = "10%", right = "8%", top = "38%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "34%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "3", height = "13%")
+        list(left = "10%", right = "8%", top = "5%", height = "16%"),
+        list(left = "10%", right = "8%", top = "39.5%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "39.5%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "21%", height = "16%"),
+        #list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
+        list(left = "10%", right = "8%", bottom = "5%", height = "16%")
       ),
       xAxis = list(
         list(
@@ -230,25 +229,6 @@ generate_chart_bars_mean <- function(
         list(
           type = "category",
           gridIndex = 4,
-          scale = TRUE,
-          boundaryGap = FALSE,
-          axisLine = list(
-            onZero = TRUE
-          ),
-          axisTick = list(
-            show = TRUE
-          ),
-          splitLine = list(
-            show = TRUE
-          ),
-          axisLabel = list(
-            show = FALSE
-          ),
-          data = time
-        ),
-        list(
-          type = "category",
-          gridIndex = 5,
           scale = TRUE,
           boundaryGap = FALSE,
           axisLine = list(
@@ -352,35 +332,12 @@ generate_chart_bars_mean <- function(
           )
         ),
         list(
-          name = "Daylength [h]",
-          nameLocation = "middle",
-          nameGap = 40,
-          nameTextStyle = list(fontWeight = "bolder"),
-          scale = TRUE,
-          gridIndex = 4,
-          splitNumber = 5,
-          min = 0,
-          max = 24,
-          axisLabel = list(
-            show = TRUE
-          ),
-          axisLine = list(
-            show = TRUE
-          ),
-          axisTick = list(
-            show = TRUE
-          ),
-          splitLine = list(
-            show = FALSE
-          )
-        ),
-        list(
           name = "PET [mm]",
           nameLocation = "middle",
           nameGap = 40,
           nameTextStyle = list(fontWeight = "bolder"),
           scale = TRUE,
-          gridIndex = 5,
+          gridIndex = 4,
           splitNumber = 5,
           min = 0,
           max = 10,

--- a/app/logic/grassland/grassland_multichart_bars_stack.R
+++ b/app/logic/grassland/grassland_multichart_bars_stack.R
@@ -106,7 +106,7 @@ generate_chart_bars_mean <- function(
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #0072B2\"></i>Precipitation [mm]: ' + param.find(item => item.seriesName ==  'Precipitation[mm]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #D55E00\"></i>Temperature [degC]: ' + param.find(item => item.seriesName ==  'Temperature[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #E69F00\"></i>Temperature Daylight [degC]: ' + param.find(item => item.seriesName ==  'Temperature_Daylight[degC]').value + '<br />' +
-              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #F0E442\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
+              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #42f09f\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #56B4E9\"></i>PET [mm]: ' + param.find(item => item.seriesName ==  'PET[mm]').value
           }
         "
@@ -149,10 +149,9 @@ generate_chart_bars_mean <- function(
       ),
       grid = list(
         list(left = "10%", right = "8%", top = "5%", height = "16%"),
-        list(left = "10%", right = "8%", top = "39.5%", height = "16%"),
-        list(left = "10%", right = "8%", bottom = "39.5%", height = "16%"),
-        list(left = "10%", right = "8%", bottom = "21%", height = "16%"),
-        #list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
+        list(left = "10%", right = "8%", top = "25%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "41%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "23%", height = "16%"),
         list(left = "10%", right = "8%", bottom = "5%", height = "16%")
       ),
       xAxis = list(

--- a/app/logic/grassland/grassland_multichart_lines.R
+++ b/app/logic/grassland/grassland_multichart_lines.R
@@ -94,7 +94,7 @@ generate_chart_lines <- function(
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #0072B2\"></i>Precipitation [mm]: ' + param.find(item => item.seriesName ==  'Precipitation[mm]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #D55E00\"></i>Temperature [degC]: ' + param.find(item => item.seriesName ==  'Temperature[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #E69F00\"></i>Temperature Daylight [degC]: ' + param.find(item => item.seriesName ==  'Temperature_Daylight[degC]').value + '<br />' +
-              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #F0E442\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
+              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #42f09f\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #56B4E9\"></i>PET [mm]: ' + param.find(item => item.seriesName ==  'PET[mm]').value
           }
         "
@@ -137,10 +137,9 @@ generate_chart_lines <- function(
       ),
       grid = list(
         list(left = "10%", right = "8%", top = "5%", height = "16%"),
-        list(left = "10%", right = "8%", top = "39.5%", height = "16%"),
-        list(left = "10%", right = "8%", bottom = "39.5%", height = "16%"),
-        list(left = "10%", right = "8%", bottom = "21%", height = "16%"),
-        #list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
+        list(left = "10%", right = "8%", top = "25%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "41%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "23%", height = "16%"),
         list(left = "10%", right = "8%", bottom = "5%", height = "16%")
       ),
       xAxis = list(

--- a/app/logic/grassland/grassland_multichart_lines.R
+++ b/app/logic/grassland/grassland_multichart_lines.R
@@ -95,7 +95,6 @@ generate_chart_lines <- function(
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #D55E00\"></i>Temperature [degC]: ' + param.find(item => item.seriesName ==  'Temperature[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #E69F00\"></i>Temperature Daylight [degC]: ' + param.find(item => item.seriesName ==  'Temperature_Daylight[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #F0E442\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
-              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #009E73\"></i>Daylength [h]: ' + param.find(item => item.seriesName ==  'Daylength[h]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #56B4E9\"></i>PET [mm]: ' + param.find(item => item.seriesName ==  'PET[mm]').value
           }
         "
@@ -137,12 +136,12 @@ generate_chart_lines <- function(
         )
       ),
       grid = list(
-        list(left = "10%", right = "8%", top = "4%", height = "13%"),
-        list(left = "10%", right = "8%", top = "22%", height = "13%"),
-        list(left = "10%", right = "8%", top = "38%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "34%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "3", height = "13%")
+        list(left = "10%", right = "8%", top = "5%", height = "16%"),
+        list(left = "10%", right = "8%", top = "39.5%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "39.5%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "21%", height = "16%"),
+        #list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
+        list(left = "10%", right = "8%", bottom = "5%", height = "16%")
       ),
       xAxis = list(
         list(
@@ -218,25 +217,6 @@ generate_chart_lines <- function(
         list(
           type = "category",
           gridIndex = 4,
-          scale = TRUE,
-          boundaryGap = FALSE,
-          axisLine = list(
-            onZero = TRUE
-          ),
-          axisTick = list(
-            show = TRUE
-          ),
-          splitLine = list(
-            show = TRUE
-          ),
-          axisLabel = list(
-            show = FALSE
-          ),
-          data = time
-        ),
-        list(
-          type = "category",
-          gridIndex = 5,
           scale = TRUE,
           boundaryGap = FALSE,
           axisLine = list(
@@ -340,35 +320,12 @@ generate_chart_lines <- function(
           )
         ),
         list(
-          name = "Daylength [h]",
-          nameLocation = "middle",
-          nameGap = 40,
-          nameTextStyle = list(fontWeight = "bolder"),
-          scale = TRUE,
-          gridIndex = 4,
-          splitNumber = 5,
-          min = 0,
-          max = 24,
-          axisLabel = list(
-            show = TRUE
-          ),
-          axisLine = list(
-            show = TRUE
-          ),
-          axisTick = list(
-            show = TRUE
-          ),
-          splitLine = list(
-            show = FALSE
-          )
-        ),
-        list(
           name = "PET [mm]",
           nameLocation = "middle",
           nameGap = 40,
           nameTextStyle = list(fontWeight = "bolder"),
           scale = TRUE,
-          gridIndex = 5,
+          gridIndex = 4,
           splitNumber = 5,
           min = 0,
           max = 10,

--- a/app/logic/grassland/grassland_multichart_lines_mean.R
+++ b/app/logic/grassland/grassland_multichart_lines_mean.R
@@ -106,7 +106,7 @@ generate_chart_lines_mean <- function(
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #0072B2\"></i>Precipitation [mm]: ' + param.find(item => item.seriesName ==  'Precipitation[mm]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #D55E00\"></i>Temperature [degC]: ' + param.find(item => item.seriesName ==  'Temperature[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #E69F00\"></i>Temperature Daylight [degC]: ' + param.find(item => item.seriesName ==  'Temperature_Daylight[degC]').value + '<br />' +
-              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #F0E442\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
+              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #42f09f\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #56B4E9\"></i>PET [mm]: ' + param.find(item => item.seriesName ==  'PET[mm]').value
           }
         "
@@ -149,10 +149,9 @@ generate_chart_lines_mean <- function(
       ),
       grid = list(
         list(left = "10%", right = "8%", top = "5%", height = "16%"),
-        list(left = "10%", right = "8%", top = "39.5%", height = "16%"),
-        list(left = "10%", right = "8%", bottom = "39.5%", height = "16%"),
-        list(left = "10%", right = "8%", bottom = "21%", height = "16%"),
-        #list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
+        list(left = "10%", right = "8%", top = "25%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "41%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "23%", height = "16%"),
         list(left = "10%", right = "8%", bottom = "5%", height = "16%")
       ),
       xAxis = list(

--- a/app/logic/grassland/grassland_multichart_lines_mean.R
+++ b/app/logic/grassland/grassland_multichart_lines_mean.R
@@ -107,7 +107,6 @@ generate_chart_lines_mean <- function(
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #D55E00\"></i>Temperature [degC]: ' + param.find(item => item.seriesName ==  'Temperature[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #E69F00\"></i>Temperature Daylight [degC]: ' + param.find(item => item.seriesName ==  'Temperature_Daylight[degC]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #F0E442\"></i>PAR [µmolm-2s-1]: ' + param.find(item => item.seriesName ==  'PAR[µmolm-2s-1]').value + '<br />' +
-              '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #009E73\"></i>Daylength [h]: ' + param.find(item => item.seriesName ==  'Daylength[h]').value + '<br />' +
               '<i class=\"fa fa-circle\" aria-hidden=\"true\" style=\"color: #56B4E9\"></i>PET [mm]: ' + param.find(item => item.seriesName ==  'PET[mm]').value
           }
         "
@@ -149,12 +148,12 @@ generate_chart_lines_mean <- function(
         )
       ),
       grid = list(
-        list(left = "10%", right = "8%", top = "4%", height = "13%"),
-        list(left = "10%", right = "8%", top = "22%", height = "13%"),
-        list(left = "10%", right = "8%", top = "38%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "34%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
-        list(left = "10%", right = "8%", bottom = "3", height = "13%")
+        list(left = "10%", right = "8%", top = "5%", height = "16%"),
+        list(left = "10%", right = "8%", top = "39.5%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "39.5%", height = "16%"),
+        list(left = "10%", right = "8%", bottom = "21%", height = "16%"),
+        #list(left = "10%", right = "8%", bottom = "18%", height = "13%"),
+        list(left = "10%", right = "8%", bottom = "5%", height = "16%")
       ),
       xAxis = list(
         list(
@@ -230,25 +229,6 @@ generate_chart_lines_mean <- function(
         list(
           type = "category",
           gridIndex = 4,
-          scale = TRUE,
-          boundaryGap = FALSE,
-          axisLine = list(
-            onZero = TRUE
-          ),
-          axisTick = list(
-            show = TRUE
-          ),
-          splitLine = list(
-            show = TRUE
-          ),
-          axisLabel = list(
-            show = FALSE
-          ),
-          data = time
-        ),
-        list(
-          type = "category",
-          gridIndex = 5,
           scale = TRUE,
           boundaryGap = FALSE,
           axisLine = list(
@@ -352,35 +332,12 @@ generate_chart_lines_mean <- function(
           )
         ),
         list(
-          name = "Daylength [h]",
-          nameLocation = "middle",
-          nameGap = 40,
-          nameTextStyle = list(fontWeight = "bolder"),
-          scale = TRUE,
-          gridIndex = 4,
-          splitNumber = 5,
-          min = 0,
-          max = 24,
-          axisLabel = list(
-            show = TRUE
-          ),
-          axisLine = list(
-            show = TRUE
-          ),
-          axisTick = list(
-            show = TRUE
-          ),
-          splitLine = list(
-            show = FALSE
-          )
-        ),
-        list(
           name = "PET [mm]",
           nameLocation = "middle",
           nameGap = 40,
           nameTextStyle = list(fontWeight = "bolder"),
           scale = TRUE,
-          gridIndex = 5,
+          gridIndex = 4,
           splitNumber = 5,
           min = 0,
           max = 10,

--- a/app/logic/grassland/grassland_read_data_weather.R
+++ b/app/logic/grassland/grassland_read_data_weather.R
@@ -1,6 +1,6 @@
 box::use(
   readr[read_delim],
-  dplyr[filter]
+  dplyr[filter, select]
 )
 
 # loads and restructure WEATHER data ----
@@ -18,7 +18,8 @@ read_weather_data <- function(
     show_col_types = FALSE,
     id = NULL,
   ) |>
-    dplyr::filter(Date <= end_date)
+    filter(Date <= end_date) |>
+    select(!Daylength[h])
 
   series <- list()
 
@@ -70,19 +71,19 @@ read_weather_data <- function(
       yAxisIndex = 3,
       data = unname(as.list(unlist(input_data[, "PAR[µmolm-2s-1]"])))
     )
+  # series[[5]] <-
+  #   list(
+  #     name = "Daylength[h]",
+  #     type = "line",
+  #     color = colors[5],
+  #     symbol = "none",
+  #     showSymbol = FALSE,
+  #     emphasis = list(disabled = TRUE),
+  #     xAxisIndex = 4,
+  #     yAxisIndex = 4,
+  #     data = unname(as.list(unlist(input_data[, "Daylength[h]"])))
+  #   )
   series[[5]] <-
-    list(
-      name = "Daylength[h]",
-      type = "line",
-      color = colors[5],
-      symbol = "none",
-      showSymbol = FALSE,
-      emphasis = list(disabled = TRUE),
-      xAxisIndex = 4,
-      yAxisIndex = 4,
-      data = unname(as.list(unlist(input_data[, "Daylength[h]"])))
-    )
-  series[[6]] <-
     list(
       name = "PET[mm]",
       type = "line",

--- a/app/logic/grassland/grassland_read_data_weather.R
+++ b/app/logic/grassland/grassland_read_data_weather.R
@@ -18,8 +18,8 @@ read_weather_data <- function(
     show_col_types = FALSE,
     id = NULL,
   ) |>
-    filter(Date <= end_date)
-  #|> select(!'Daylength[h]')
+    filter(Date <= end_date) |>
+    select(!'Daylength[h]')
 
   series <- list()
 
@@ -71,18 +71,6 @@ read_weather_data <- function(
       yAxisIndex = 3,
       data = unname(as.list(unlist(input_data[, "PAR[µmolm-2s-1]"])))
     )
-  # series[[5]] <-
-  #   list(
-  #     name = "Daylength[h]",
-  #     type = "line",
-  #     color = colors[5],
-  #     symbol = "none",
-  #     showSymbol = FALSE,
-  #     emphasis = list(disabled = TRUE),
-  #     xAxisIndex = 4,
-  #     yAxisIndex = 4,
-  #     data = unname(as.list(unlist(input_data[, "Daylength[h]"])))
-  #   )
   series[[5]] <-
     list(
       name = "PET[mm]",
@@ -91,8 +79,8 @@ read_weather_data <- function(
       symbol = "none",
       showSymbol = FALSE,
       emphasis = list(disabled = TRUE),
-      xAxisIndex = 5,
-      yAxisIndex = 5,
+      xAxisIndex = 4,
+      yAxisIndex = 4,
       data = unname(as.list(unlist(input_data[, "PET[mm]"])))
     )
 

--- a/app/logic/grassland/grassland_read_data_weather.R
+++ b/app/logic/grassland/grassland_read_data_weather.R
@@ -18,8 +18,8 @@ read_weather_data <- function(
     show_col_types = FALSE,
     id = NULL,
   ) |>
-    filter(Date <= end_date) |>
-    select(!Daylength[h])
+    filter(Date <= end_date)
+  #|> select(!'Daylength[h]')
 
   series <- list()
 

--- a/app/view/grassland/grassland_dynamics/grassland_dynamics_weather_grass_chart.R
+++ b/app/view/grassland/grassland_dynamics/grassland_dynamics_weather_grass_chart.R
@@ -92,7 +92,7 @@ grassland_dynamics_double_chart_server <- function(id, plot_type, tab_grassland_
 
         colors_for_grass <- c("#18A547", "#AF2C6E", "#422CAF")
         colors_for_grass_lighter <- c("#73eb9b", "#e28bb7", "#998be2")
-        colors_for_weather <- c("#0072B2", "#D55E00", "#E69F00", "#F0E442", "#009E73", "#56B4E9")
+        colors_for_weather <- c("#0072B2", "#D55E00", "#E69F00", "#42f09f", "#56B4E9")
         end_date <- "2015-12-31"
 
         chart_reactive <- reactive({

--- a/app/view/grassland/grassland_dynamics/grassland_dynamics_weather_grass_chart_controls.R
+++ b/app/view/grassland/grassland_dynamics/grassland_dynamics_weather_grass_chart_controls.R
@@ -19,11 +19,11 @@ grassland_dynamics_double_chart_controls_ui <- function(id, i18n) {
     card_body(
       radioButtons(
         inputId = ns("line_or_bar"),
-        label = i18n$translate("Plot type:"),
+        label = i18n$translate("PFT plot type:"),
         choices = list(
-          "Bars - PFT's mean" = "bar",
-          "Lines - PFT's mean" = "line_mean",
-          "Lines - all PFT" = "line"
+          "Bars - mean over all runs" = "bar",
+          "Lines - mean over all runs" = "line_mean",
+          "Lines - all runs" = "line"
         ),
         selected = "bar"
       )


### PR DESCRIPTION
Thomas wrote:

- weather data plots: remove the Daylength plot (very little informative value) and use the colour green for PAR instead (yellow is a bit hard to see)
- plot type labels (under "Controls"): rename to "PFT plot type: Bars - mean over all runs, Lines - mean over all runs, Lines - all runs"

Should be done. Regarding that change from yellow to green, I think it wasn't good step...

Anyway, you can take a look. More to come...:-)