### PR TITLE
less prominent soil data table

### DIFF
--- a/app/view/grassland/grassland_dynamics/grassland_dynamics_soil_main_values.R
+++ b/app/view/grassland/grassland_dynamics/grassland_dynamics_soil_main_values.R
@@ -5,7 +5,7 @@ box::use(
 )
 
 box::use(
-  app/logic/waiter[waiter_text],
+  app / logic / waiter[waiter_text],
 )
 
 #' @export
@@ -15,7 +15,7 @@ grassland_dynamics_soil_main_values_ui <- function(
 ) {
   ns <- NS(id)
   card(
-    id = "soil_main_values",
+    id = ns("soil_main_values"),
     class = "mx-md-3 card-shadow mb-2",
     card_header(
       tags$h2(
@@ -51,22 +51,20 @@ grassland_dynamics_soil_main_values_ui <- function(
 
 #' @export
 grassland_dynamics_soil_main_values_server <- function(
-    id,
-    main_values,
-    tab_grassland_selected
-  ) {
+  id,
+  main_values,
+  tab_grassland_selected
+) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     # Define waiter ----
-    msg <- waiter_text(message = tags$h3("Loading...",
-        style = "color: #414f2f;"
-      ))
+    msg <- waiter_text(message = tags$h3("Loading...", style = "color: #414f2f;"))
     w <- Waiter$new(
       id = ns("soil_main_values"),
       html = msg,
       color = "rgba(256,256,256,0.9)",
     )
-  
+
     observeEvent(
       tab_grassland_selected(),
       ignoreNULL = TRUE,
@@ -76,15 +74,21 @@ grassland_dynamics_soil_main_values_server <- function(
         main_values_reactive <- reactiveVal()
         main_values_reactive(main_values)
 
-        output$silt <- renderText({ names(main_values_reactive())[1] })
-        output$clay <- renderText({ names(main_values_reactive())[2] })
-        output$sand <- renderText({ names(main_values_reactive())[3] })
+        output$silt <- renderText({
+          names(main_values_reactive())[1]
+        })
+        output$clay <- renderText({
+          names(main_values_reactive())[2]
+        })
+        output$sand <- renderText({
+          names(main_values_reactive())[3]
+        })
 
         output$silt_val <- renderText(main_values_reactive()[[1]])
         output$clay_val <- renderText(main_values_reactive()[[2]])
         output$sand_val <- renderText(main_values_reactive()[[3]])
         w$hide()
       }
-    )    
+    )
   })
 }


### PR DESCRIPTION
This one from Thomas:

> "- soil data (composition and layered hydrological properties): we think the soil data could be less prominent, some way to click on a button or similar to expand the "Soil data" and then get to see the details as a table would be sufficient"

is finished. I solved very simple - by small checkbox under card's heading. Looks good imho, not obtrusive.

![image](https://github.com/user-attachments/assets/cb736bc1-5e63-43ae-98fe-bc154e1ee7d8)

![image](https://github.com/user-attachments/assets/7527ed43-82d7-45c2-8e1d-b25ac1738a33)
